### PR TITLE
Replace multiply by 2 (i*2) with left shift. 

### DIFF
--- a/kernel/ckolivas.cl
+++ b/kernel/ckolivas.cl
@@ -835,11 +835,11 @@ const uint4 midstate0, const uint4 midstate16, const uint target)
 	{
 		pad0 = tstate0;
 		pad1 = tstate1;
-		X[i*2 ] = ostate0;
-		X[i*2+1] = ostate1;
+		X[i<<1 ] = ostate0;
+		X[(i<<1)+1] = ostate1;
 
 		SHA256(&pad0,&pad1, data, (uint4)(i+1,K[84],0,0), (uint4)(0,0,0,0), (uint4)(0,0,0, K[87]));
-		SHA256(X+i*2,X+i*2+1, pad0, pad1, (uint4)(K[84], 0U, 0U, 0U), (uint4)(0U, 0U, 0U, K[88]));
+		SHA256(X+(i<<1),X+(i<<1)+1, pad0, pad1, (uint4)(K[84], 0U, 0U, 0U), (uint4)(0U, 0U, 0U, K[88]));
 	}
 	scrypt_core(X,padcache);
 	SHA256(&tmp0,&tmp1, X[0], X[1], X[2], X[3]);

--- a/kernel/zuikkis.cl
+++ b/kernel/zuikkis.cl
@@ -823,11 +823,11 @@ const uint4 midstate0, const uint4 midstate16, const uint target)
 	{
 		pad0 = tstate0;
 		pad1 = tstate1;
-		X[i*2 ] = ostate0;
-		X[i*2+1] = ostate1;
+		X[i<<1 ] = ostate0;
+		X[(i<<1)+1] = ostate1;
 
 		SHA256(&pad0,&pad1, data, (uint4)(i+1,K[84],0,0), (uint4)(0,0,0,0), (uint4)(0,0,0, K[87]));
-		SHA256(X+i*2,X+i*2+1, pad0, pad1, (uint4)(K[84], 0U, 0U, 0U), (uint4)(0U, 0U, 0U, K[88]));
+		SHA256(X+(i<<1),X+(i<<1)+1, pad0, pad1, (uint4)(K[84], 0U, 0U, 0U), (uint4)(0U, 0U, 0U, K[88]));
 	}
 	scrypt_core(X,padcache);
 	SHA256(&tmp0,&tmp1, X[0], X[1], X[2], X[3]);


### PR DESCRIPTION
This should be slightly faster. Can't use OpenCL rotate because of bit carry overs.
