### PR TITLE
Update configure.ac [bug] psw kernel missing fixed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,7 @@ AC_DEFINE_UNQUOTED([ALEXKARNEW_KERNNAME], ["alexkarnew"], [Filename for Alexey K
 AC_DEFINE_UNQUOTED([ALEXKAROLD_KERNNAME], ["alexkarold"], [Filename for Alexey Karimov's optimised kernel for Catalyst <13.4])
 AC_DEFINE_UNQUOTED([CKOLIVAS_KERNNAME], ["ckolivas"], [Filename for original scrypt kernel])
 AC_DEFINE_UNQUOTED([ZUIKKIS_KERNNAME], ["zuikkis"], [Filename for Zuikkis' optimised kernel])
+AC_DEFINE_UNQUOTED([PSW_KERNNAME], ["psw"], [Filename for psw optimised kernel])
 
 AC_SUBST(OPENCL_LIBS)
 AC_SUBST(OPENCL_FLAGS)


### PR DESCRIPTION
Looks like this was missed, currently the build is broken until this goes in.
