### PR TITLE
Replace second ZUIKKIS_KERNNAME for PSW_KERNNAME

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -338,7 +338,7 @@ AC_DEFINE_UNQUOTED([ALEXKARNEW_KERNNAME], ["alexkarnew"], [Filename for Alexey K
 AC_DEFINE_UNQUOTED([ALEXKAROLD_KERNNAME], ["alexkarold"], [Filename for Alexey Karimov's optimised kernel for Catalyst <13.4])
 AC_DEFINE_UNQUOTED([CKOLIVAS_KERNNAME], ["ckolivas"], [Filename for original scrypt kernel])
 AC_DEFINE_UNQUOTED([ZUIKKIS_KERNNAME], ["zuikkis"], [Filename for Zuikkis' optimised kernel])
-AC_DEFINE_UNQUOTED([ZUIKKIS_KERNNAME], ["psw"], [Filename for psw's experimental kernel])
+AC_DEFINE_UNQUOTED([PSW_KERNNAME], ["psw"], [Filename for psw's experimental kernel])
 
 AC_SUBST(OPENCL_LIBS)
 AC_SUBST(OPENCL_FLAGS)


### PR DESCRIPTION
Build still broken:

sgminer.c: In function âwrite_configâ:
sgminer.c:4193: error: âPSW_KERNNAMEâ undeclared (first use in this function)
sgminer.c:4193: error: (Each undeclared identifier is reported only once
sgminer.c:4193: error: for each function it appears in.)
