### PR TITLE
Update README.txt

### DIFF
--- a/winbuild/README.txt
+++ b/winbuild/README.txt
@@ -1,3 +1,9 @@
+Tools needed
+------------
+1. Visual Studio Express - found at http://www.visualstudio.com/en-US/products/visual-studio-express-vs
+2. Windows SDK - can be downloaded from microsoft.com
+
+
 Installing dependencies
 -----------------------
 


### PR DESCRIPTION
In order to compile curl, you need to have Windows SDK installed.
Windows SDK is not needed to compiled the other libraries.
