### PR TITLE
API: Fixed timeval struct formatting .

### DIFF
--- a/api.c
+++ b/api.c
@@ -1005,9 +1005,9 @@ static struct api_data *print_data(struct api_data *root, char *buf, bool isjson
 				sprintf(buf, "%s", *((bool *)(root->data)) ? TRUESTR : FALSESTR);
 				break;
 			case API_TIMEVAL:
-				snprintf(buf, sizeof(buf), "%ld.%06ld",
-					(long)((struct timeval *)(root->data))->tv_sec,
-					(long)((struct timeval *)(root->data))->tv_usec);
+				snprintf(buf, sizeof(buf), "%"PRIu64".%06lu",
+					(uint64_t)((struct timeval *)(root->data))->tv_sec,
+					(unsigned long)((struct timeval *)(root->data))->tv_usec);
 				break;
 			case API_TEMP:
 				sprintf(buf, "%.2f", *((float *)(root->data)));


### PR DESCRIPTION
Without this change API commands "coin" and "stats" are broken, i.e. returned data is corrupted.
