### PR TITLE
Add API read support for xintensity/rawintensity.

### DIFF
--- a/api.c
+++ b/api.c
@@ -1660,6 +1660,10 @@ static void gpustatus(struct io_data *io_data, int gpu, bool isjson, bool precom
 
 		if (cgpu->dynamic)
 			strcpy(intensity, DYNAMIC);
+		else if (cgpu->xintensity > 0)
+			sprintf(intensity, "X%d", cgpu->xintensity);
+		else if (cgpu->rawintensity > 0)
+			sprintf(intensity, "R%d", cgpu->rawintensity);
 		else
 			sprintf(intensity, "%d", cgpu->intensity);
 


### PR DESCRIPTION
Add support for reading X Intensity and Raw Intensity.
Prepend returned intensity with "X" or "R" as appropriate. This
approach should provide backward compatability with most API users,
unless they're treating the return value as a int.

Issue #99.
