### PR TITLE
added clarification for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,7 @@ sgminer-specific configuration options:
     
 #### Debian Example
 
-    apt-get install libcurl4-openssl-dev
-    apt-get install pkg-config
-    apt-get install libtool
-    apt-get install libncurses5-dev
+    apt-get install libcurl4-openssl-dev pkg-config libtool libncurses5-dev
 AMD APP SDK and AMD ADL SDK must be downloaded from the amd websites.
 
 ### *nix build instructions


### PR DESCRIPTION
Improved clarity of dependencies by adding example of how to install dependencies using apt-get. It was not clear whether `autoreconf -i` would install the dependencies or not. And how to install the dependencies if a user doesn't know how.
