### PR TITLE
Update sgminer.c

### DIFF
--- a/sgminer.c
+++ b/sgminer.c
@@ -1717,7 +1717,7 @@ void free_work(struct work *w)
 	free(w);
 }
 
-static void gen_hash(unsigned char *data, unsigned char *hash, int len);
+static void gen_hash(unsigned char *data, unsigned char *hash, size_t len);
 static void calc_diff(struct work *work, double known);
 char *workpadding = "000000800000000000000000000000000000000000000000000000000000000000000000000000000000000080020000";
 
@@ -5889,7 +5889,7 @@ out_unlock:
 	return work;
 }
 
-static void gen_hash(unsigned char *data, unsigned char *hash, int len)
+static void gen_hash(unsigned char *data, unsigned char *hash, size_t len)
 {
 	unsigned char hash1[32];
 


### PR DESCRIPTION
One small change to work well with previous ones.
Number of warnings now is 151, down from 157.

Still a long way to go. Most of the serious warnings are related to variables in miner.h, which is so intertwined with everything else that I fear of breaking something or making performance worse if I touch miner.h too much.
