### PR TITLE
initial_args warning

### DIFF
--- a/sgminer.c
+++ b/sgminer.c
@@ -3243,10 +3243,7 @@ void kill_work(void)
 	quit(0, "Shutdown signal received.");
 }
 
-#ifdef WIN32
-const
-#endif
-char **initial_args;
+static const char **initial_args;
 
 static void clean_up(bool restarting);
 
@@ -7940,12 +7937,7 @@ int main(int argc, char *argv[])
 		quithere(1, "Failed to pthread_mutex_init lockstat_lock errno=%d", errno);
 #endif
 
-#ifdef WIN32
 	initial_args = (const char **)malloc(sizeof(char *)* (argc + 1));
-#else
-	initial_args = (char **)malloc(sizeof(char *)* (argc + 1));
-#endif
-
 	for  (i = 0; i < argc; i++)
 		initial_args[i] = strdup(argv[i]);
 	initial_args[argc] = NULL;


### PR DESCRIPTION
Provide for WIN32 and non-WIN32 condition for initial_args malloc (compiler warning)
and remove redundant static.
