### PR TITLE
Add support for Diamond v2

### DIFF
--- a/algorithm.c
+++ b/algorithm.c
@@ -623,6 +623,9 @@ static algorithm_settings_t algos[] = {
   A_FUGUE( "groestlcoin", groestlcoin_regenhash),
 #undef A_FUGUE
 
+  // Diamond uses the same hashing as GroestlCoin, but the traditional sha256d for transactions
+  { "diamond", ALGO_FUGUE, 1, 256, 256, 0, 0, 0xFF, 0xFFFFULL, 0x0000ffffUL, 0, 0, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, groestlcoin_regenhash, queue_sph_kernel, gen_hash, NULL},
+
   // Terminator (do not remove)
   { NULL, ALGO_UNK, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL}
 };


### PR DESCRIPTION
Diamond v2 switched to Groestl from scrypt. Unlike GroestlCoin however, it uses the common double sha256 transaction hashing.
