### PR TITLE
If extranonce subscribe failed, do not consider it as fatal error

### DIFF
--- a/sgminer.c
+++ b/sgminer.c
@@ -5562,7 +5562,10 @@ retry_stratum:
     bool init = pool_tset(pool, &pool->stratum_init);
 
     if (!init) {
-      bool ret = initiate_stratum(pool) && (!pool->extranonce_subscribe || subscribe_extranonce(pool)) && auth_stratum(pool);
+      bool ret = initiate_stratum(pool);
+      if (pool->extranonce_subscribe)
+        subscribe_extranonce(pool);
+      ret = ret && auth_stratum(pool);
 
       if (ret)
         init_stratum_threads(pool);

--- a/util.c
+++ b/util.c
@@ -1944,7 +1944,7 @@ bool subscribe_extranonce(struct pool *pool)
     }
     else
       ss = strdup("(unknown reason)");
-    applog(LOG_INFO, "%s JSON stratum auth failed: %s", get_pool_name(pool), ss);
+    applog(LOG_INFO, "%s JSON stratum extranonce subscribe failed: %s", get_pool_name(pool), ss);
     free(ss);
 
     goto out;
@@ -2591,8 +2591,8 @@ bool restart_stratum(struct pool *pool)
     suspend_stratum(pool);
   if (!initiate_stratum(pool))
     return false;
-  if (pool->extranonce_subscribe && !subscribe_extranonce(pool))
-    return false;
+  if (pool->extranonce_subscribe)
+    subscribe_extranonce(pool);
   if (!auth_stratum(pool))
     return false;
 


### PR DESCRIPTION
Someone please review this and let me know if it makes sense.
Possibly related issue: https://github.com/sgminer-dev/sgminer/issues/332
Basically if extranonce subscribe fails, I think sgminer should still proceed with auth and use the pool as per normal.

CC @troky @ystarnaud
