### PR TITLE
Fix errors compiling on OS X

### DIFF
--- a/algorithm/animecoin.c
+++ b/algorithm/animecoin.c
@@ -52,6 +52,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void animehash(void *state, const void *input)
 {
     sph_blake512_context     ctx_blake;

--- a/algorithm/bitblock.c
+++ b/algorithm/bitblock.c
@@ -106,6 +106,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void bitblockhash(void *state, const void *input)
 {
     init_Bhash_contexts();

--- a/algorithm/fresh.c
+++ b/algorithm/fresh.c
@@ -75,6 +75,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void freshHash(void *state, const void *input)
 {
   init_freshHash_contexts();

--- a/algorithm/fuguecoin.c
+++ b/algorithm/fuguecoin.c
@@ -47,6 +47,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void fuguehash(void *state, const void *input)
 {
     sph_fugue256_context ctx_fugue;

--- a/algorithm/groestlcoin.c
+++ b/algorithm/groestlcoin.c
@@ -51,6 +51,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void groestlhash(void *state, const void *input)
 {
     sph_groestl512_context ctx_groestl;

--- a/algorithm/inkcoin.c
+++ b/algorithm/inkcoin.c
@@ -90,6 +90,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 		dst[i] = htobe32(src[i]);
 }
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void inkhash(void *state, const void *input)
 {
     uint32_t hash[16];

--- a/algorithm/marucoin.c
+++ b/algorithm/marucoin.c
@@ -100,6 +100,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void maruhash(void *state, const void *input)
 {
     init_Mhash_contexts();

--- a/algorithm/myriadcoin-groestl.c
+++ b/algorithm/myriadcoin-groestl.c
@@ -51,6 +51,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void mghash(void *state, const void *input)
 {
     sph_groestl512_context ctx_groestl;

--- a/algorithm/quarkcoin.c
+++ b/algorithm/quarkcoin.c
@@ -52,6 +52,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void quarkhash(void *state, const void *input)
 {
     sph_blake512_context     ctx_blake;

--- a/algorithm/qubitcoin.c
+++ b/algorithm/qubitcoin.c
@@ -77,6 +77,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void qhash(void *state, const void *input)
 {
     init_Qhash_contexts();

--- a/algorithm/sifcoin.c
+++ b/algorithm/sifcoin.c
@@ -52,6 +52,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void sifhash(void *state, const void *input)
 {
     sph_blake512_context     ctx_blake;

--- a/algorithm/talkcoin.c
+++ b/algorithm/talkcoin.c
@@ -72,6 +72,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void talkhash(void *state, const void *input)
 {
   init_Nhash_contexts();

--- a/algorithm/twecoin.c
+++ b/algorithm/twecoin.c
@@ -53,6 +53,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void twehash(void *state, const void *input)
 {
     sph_fugue256_context     ctx_fugue;

--- a/algorithm/whirlcoin.c
+++ b/algorithm/whirlcoin.c
@@ -69,6 +69,9 @@ be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len)
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void whirlcoin_hash(void *state, const void *input)
 {
     init_whirlcoin_hash_contexts();

--- a/algorithm/x14.c
+++ b/algorithm/x14.c
@@ -101,6 +101,9 @@ static inline void be32enc_vect(uint32_t *dst, const uint32_t *src, uint32_t len
 }
 
 
+#ifdef __APPLE_CC__
+static
+#endif
 inline void x14hash(void *state, const void *input)
 {
   init_X14hash_contexts();


### PR DESCRIPTION
e.g. Undefined symbols for architecture x86_64:
  "_quarkhash", referenced from:
      _quarkcoin_test in sgminer-quarkcoin.o
      _quarkcoin_regenhash in sgminer-quarkcoin.o
      _scanhash_quarkcoin in sgminer-quarkcoin.o

See: http://clang.llvm.org/compatibility.html#inline